### PR TITLE
Expose the difference between updating I18n load path in application.rb vs initializer.

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -133,6 +133,8 @@ I18n.available_locales = [:en, :pt]
 I18n.default_locale = :pt
 ```
 
+WARNING. When updating the I18n load path in an initializer, it is possible that other translation files be appended to the load path later in the initialization process. This may result in your local translations being overriden.
+
 ### Managing the Locale across Requests
 
 The default locale is used for all translations unless `I18n.locale` is explicitly set.


### PR DESCRIPTION
Context
---
The guides make it seem like updating the I18n load path in the `application.rb` or an initializer will result in the same outcome.
This is incorrect.